### PR TITLE
Add AP2 MCP Kestra workflows

### DIFF
--- a/ysh/domains/ap2/workflows/kestra/credentials_provider_flow.yml
+++ b/ysh/domains/ap2/workflows/kestra/credentials_provider_flow.yml
@@ -1,0 +1,90 @@
+id: ysh.ap2.credentials_provider_mcp
+namespace: ysh.ap2
+description: >-
+  Workflow Kestra que automatiza a chamada ao endpoint MCP do CredentialsProviderAgent
+  para fornecer métodos de pagamento, endereço de entrega e tokenização segura
+  de credenciais conforme o protocolo AP2.
+inputs:
+  - name: cart_mandate_json
+    type: STRING
+    required: true
+    description: Mandato de carrinho assinado pelo comerciante (JSON serializado).
+  - name: payment_method_id
+    type: STRING
+    required: true
+    description: Identificador do método de pagamento preferido pelo usuário.
+  - name: shipping_options_json
+    type: STRING
+    required: true
+    description: Opções para recuperar endereço de entrega (use "{}" quando não houver preferências).
+tasks:
+  - id: fetch_payment_methods
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://credentials-provider:8002/mcp/credentials_provider"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "source": "kestra.credentials_provider_mcp"
+        },
+        "skill": {
+          "id": "get_eligible_payment_methods",
+          "parameters": {
+            "cart_mandate": {{ inputs.cart_mandate_json }}
+          }
+        }
+      }
+  - id: fetch_shipping_address
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://credentials-provider:8002/mcp/credentials_provider"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "source": "kestra.credentials_provider_mcp"
+        },
+        "skill": {
+          "id": "get_shipping_address",
+          "parameters": {
+            "options": {{ inputs.shipping_options_json }}
+          }
+        }
+      }
+  - id: create_payment_token
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://credentials-provider:8002/mcp/credentials_provider"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "source": "kestra.credentials_provider_mcp"
+        },
+        "skill": {
+          "id": "create_payment_credential_token",
+          "parameters": {
+            "payment_method_id": "{{ inputs.payment_method_id }}",
+            "cart_mandate": {{ inputs.cart_mandate_json }}
+          }
+        }
+      }
+  - id: sign_payment_mandate
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://credentials-provider:8002/mcp/credentials_provider"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "source": "kestra.credentials_provider_mcp"
+        },
+        "skill": {
+          "id": "sign_payment_mandate",
+          "parameters": {
+            "cart_mandate": {{ inputs.cart_mandate_json }},
+            "payment_mandate_contents": {{ outputs.create_payment_token.body }}
+          }
+        }
+      }

--- a/ysh/domains/ap2/workflows/kestra/merchant_checkout_flow.yml
+++ b/ysh/domains/ap2/workflows/kestra/merchant_checkout_flow.yml
@@ -1,0 +1,139 @@
+id: ysh.ap2.merchant_checkout
+namespace: ysh.ap2
+description: >-
+  Orquestra o fluxo MCP do MerchantAgent desde a descoberta de produtos até a
+  iniciação do pagamento e finalização com credencial digital.
+inputs:
+  - name: shopping_agent_id
+    type: STRING
+    required: true
+    description: Identificador do agente comprador autorizado a interagir com o comerciante.
+  - name: intent_query
+    type: STRING
+    required: true
+    description: Descrição em linguagem natural do que o usuário deseja comprar.
+  - name: cart_id
+    type: STRING
+    required: true
+    description: Identificador do carrinho que será atualizado.
+  - name: cart_items_json
+    type: STRING
+    required: true
+    description: Lista de itens (JSON) que serão mantidos no carrinho após a curadoria.
+  - name: payment_options_json
+    type: STRING
+    required: true
+    description: Estrutura JSON com regras de pagamento e fulfillment para o mandato do carrinho.
+  - name: shipping_address_json
+    type: STRING
+    required: true
+    description: Endereço de entrega fornecido pelo CredentialsProviderAgent (JSON).
+  - name: payment_method_json
+    type: STRING
+    required: true
+    description: Método de pagamento tokenizado pronto para iniciar a transação.
+  - name: payment_mandate_json
+    type: STRING
+    required: true
+    description: Mandato de pagamento assinado pelo CredentialsProviderAgent.
+  - name: dpc_response_json
+    type: STRING
+    required: true
+    description: Resposta do provedor de credenciais digitais para concluir a compra.
+tasks:
+  - id: search_catalog
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-agent:8001/mcp/merchant_agent"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "shopping_agent_id": "{{ inputs.shopping_agent_id }}"
+        },
+        "skill": {
+          "id": "search_catalog",
+          "parameters": {
+            "query": "{{ inputs.intent_query }}",
+            "intent_mandate": {
+              "natural_language_description": "{{ inputs.intent_query }}"
+            }
+          }
+        }
+      }
+  - id: create_cart_mandate
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-agent:8001/mcp/merchant_agent"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "shopping_agent_id": "{{ inputs.shopping_agent_id }}"
+        },
+        "skill": {
+          "id": "create_cart_mandate",
+          "parameters": {
+            "cart_id": "{{ inputs.cart_id }}",
+            "payment_options": {{ inputs.payment_options_json }}
+          }
+        }
+      }
+  - id: update_cart_with_shipping
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-agent:8001/mcp/merchant_agent"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "shopping_agent_id": "{{ inputs.shopping_agent_id }}"
+        },
+        "skill": {
+          "id": "update_cart",
+          "parameters": {
+            "cart_id": "{{ inputs.cart_id }}",
+            "operation": "merge",
+            "items": {{ inputs.cart_items_json }},
+            "shipping_address": {{ inputs.shipping_address_json }},
+            "cart_mandate": {{ outputs.create_cart_mandate.body }}
+          }
+        }
+      }
+  - id: initiate_payment
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-agent:8001/mcp/merchant_agent"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "shopping_agent_id": "{{ inputs.shopping_agent_id }}"
+        },
+        "skill": {
+          "id": "initiate_payment",
+          "parameters": {
+            "cart_mandate": {{ outputs.create_cart_mandate.body }},
+            "payment_mandate": {{ inputs.payment_mandate_json }},
+            "payment_method": {{ inputs.payment_method_json }}
+          }
+        }
+      }
+  - id: finalize_with_dpc
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-agent:8001/mcp/merchant_agent"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "shopping_agent_id": "{{ inputs.shopping_agent_id }}"
+        },
+        "skill": {
+          "id": "dpc_finish",
+          "parameters": {
+            "cart_mandate": {{ outputs.create_cart_mandate.body }},
+            "dpc_response": {{ inputs.dpc_response_json }}
+          }
+        }
+      }

--- a/ysh/domains/ap2/workflows/kestra/payment_processor_flow.yml
+++ b/ysh/domains/ap2/workflows/kestra/payment_processor_flow.yml
@@ -1,0 +1,122 @@
+id: ysh.ap2.payment_processor
+namespace: ysh.ap2
+description: >-
+  Automatiza a execução das skills MCP do MerchantPaymentProcessorAgent para
+  validar mandato, aplicar desafio OTP e concluir a liquidação de pagamentos AP2.
+inputs:
+  - name: transaction_id
+    type: STRING
+    required: true
+    description: Identificador único da transação em processamento.
+  - name: cart_mandate_json
+    type: STRING
+    required: true
+    description: Mandato de carrinho recebido do MerchantAgent.
+  - name: payment_mandate_json
+    type: STRING
+    required: true
+    description: Mandato de pagamento assinado pelo CredentialsProviderAgent.
+  - name: payment_method_json
+    type: STRING
+    required: true
+    description: Método de pagamento tokenizado que deve ser roteado ao processador.
+  - name: challenge_type
+    type: STRING
+    required: true
+    description: Canal preferencial para autenticação (ex.: "sms" ou "email").
+  - name: challenge_response
+    type: STRING
+    required: true
+    description: Resposta capturada do usuário para o desafio solicitado.
+tasks:
+  - id: initiate_processor_payment
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-payment-processor:8003/mcp/merchant_payment_processor"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "transaction_id": "{{ inputs.transaction_id }}"
+        },
+        "skill": {
+          "id": "initiate_payment",
+          "parameters": {
+            "cart_mandate": {{ inputs.cart_mandate_json }},
+            "payment_mandate": {{ inputs.payment_mandate_json }},
+            "payment_method": {{ inputs.payment_method_json }}
+          }
+        }
+      }
+  - id: handle_mandate_validation
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-payment-processor:8003/mcp/merchant_payment_processor"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "transaction_id": "{{ inputs.transaction_id }}"
+        },
+        "skill": {
+          "id": "handle_payment_mandate",
+          "parameters": {
+            "payment_mandate": {{ inputs.payment_mandate_json }},
+            "cart_mandate": {{ inputs.cart_mandate_json }}
+          }
+        }
+      }
+  - id: raise_otp_challenge
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-payment-processor:8003/mcp/merchant_payment_processor"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "transaction_id": "{{ inputs.transaction_id }}"
+        },
+        "skill": {
+          "id": "raise_challenge",
+          "parameters": {
+            "transaction_id": "{{ inputs.transaction_id }}",
+            "challenge_type": "{{ inputs.challenge_type }}"
+          }
+        }
+      }
+  - id: verify_otp_response
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-payment-processor:8003/mcp/merchant_payment_processor"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "transaction_id": "{{ inputs.transaction_id }}"
+        },
+        "skill": {
+          "id": "verify_challenge_response",
+          "parameters": {
+            "transaction_id": "{{ inputs.transaction_id }}",
+            "challenge_response": "{{ inputs.challenge_response }}"
+          }
+        }
+      }
+  - id: complete_payment
+    type: io.kestra.plugin.core.http.Http
+    method: POST
+    uri: "http://merchant-payment-processor:8003/mcp/merchant_payment_processor"
+    contentType: application/json
+    body: |
+      {
+        "context": {
+          "transaction_id": "{{ inputs.transaction_id }}"
+        },
+        "skill": {
+          "id": "complete_payment",
+          "parameters": {
+            "transaction_id": "{{ inputs.transaction_id }}",
+            "payment_mandate": {{ inputs.payment_mandate_json }}
+          }
+        }
+      }


### PR DESCRIPTION
## Summary
- add Kestra workflows that orchestrate MCP skills for the CredentialsProviderAgent
- provide a merchant checkout workflow chaining catalog, cart, payment initiation and DPC finalization steps
- automate payment processor agent challenges and completion via MCP HTTP calls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d123d8035883329ef3e27a8eb73dec