### PR TITLE
Add MCP E2E 360 manifests and docs

### DIFF
--- a/ysh/docs/topics/ap2-a2a-and-mcp.md
+++ b/ysh/docs/topics/ap2-a2a-and-mcp.md
@@ -27,6 +27,10 @@ Desenvolvedores podem implementar suas próprias ferramentas para integrar com p
 
 Estamos trabalhando em servidores MCP para AP2.
 
+### Suite MCP E2E 360°
+
+O manifesto [`ap2.e2e360.suite.json`](../../domains/ap2/mcp/manifests/ap2.e2e360.suite.json) consolida os fluxos humano-presente e humano-não-presente, bem como o onboarding de credenciais compatíveis. Ele referencia explicitamente os agentes de Shopping, Merchant, Credentials Provider e Payment Processor, define playbooks MCP (`ap2.e2e.human_present_checkout`, `ap2.e2e.human_absent_checkout`, `ap2.e2e.enable_payment_method`) e aponta as métricas de observabilidade necessárias (`checkout_latency_ms`, `otp_retry_count`). Junto ao manifesto [`pre.e2e360.suite.json`](../../domains/origination-viabilidade/mcp/manifests/pre.e2e360.suite.json), cobrimos 360° do blueprint PRE ↔ AP2 descrito no PRD.
+
 ---
 
 Em essência, **A2A e MCP fornecem as camadas fundamentais de comunicação e interação para agentes de IA**, permitindo que eles se conectem e executem tarefas. **AP2 constrói sobre essas camadas adicionando uma extensão de pagamentos especializada e segura**, abordando os desafios únicos de autorização, autenticidade e responsabilidade em pagamentos orientados por IA. Isso permite que agentes naveguem, negociem, comprem e vendam com confiança em nome dos usuários, estabelecendo prova verificável de intenção e responsabilidade clara nas transações.

--- a/ysh/domains/ap2/docs/MCP_E2E.md
+++ b/ysh/domains/ap2/docs/MCP_E2E.md
@@ -1,0 +1,18 @@
+# MCP E2E — AP2 Payments 360°
+
+O manifesto [`ap2.e2e360.suite.json`](../mcp/manifests/ap2.e2e360.suite.json) consolida todo o blueprint AP2 para compras com agentes. Ele documenta as dependências entre Shopping Agent, Merchant, Credentials Provider e Payment Processor, além de definir três playbooks MCP:
+
+1. **`ap2.e2e.human_present_checkout`** – fluxo humano-presente ponta-a-ponta (intent → carrinho → tokenização → OTP → recibo) com watch.log e métricas de latência.
+2. **`ap2.e2e.human_absent_checkout`** – delega Intent Mandate, monta carrinho offline e usa callbacks para concluir o pagamento em ausência humana.
+3. **`ap2.e2e.enable_payment_method`** – ativa/tokeniza métodos compatíveis com o comerciante e emite o evento `ap2.credential.tokenized.v1`.
+
+Cada playbook referencia explicitamente os delegates MCP/A2A que precisam ser encadeados, garantindo rastreabilidade 360° e facilitando os testes E2E descritos no PRD. O manifesto também lista eventos publicados/consumidos e os indicadores de observabilidade (watch.log, latência, contagem de OTPs).
+
+## Como executar no testbed local
+
+1. **Iniciar agentes A2A/MCP**: utilize os scripts `uv run --package ap2-samples python -m roles.<agent>` descritos em `ysh/core/python/scenarios` para subir shopping, merchant, credentials e processor.
+2. **Ativar o servidor MCP (FastAPI)**: cada agente expõe `POST /mcp/<agent>` conforme descrito no manifesto. Ao rodar os serviços Python, utilize o parâmetro `--enable-mcp` para abrir o endpoint MCP paralelo ao A2A.
+3. **Chamar o playbook**: envie um POST para `http://localhost:8000/mcp/shopping_agent` (ou para o gateway orquestrador) com o corpo do manifesto correspondente. As respostas devem conter recibos, mandates e caminhos de log apontados no manifesto.
+4. **Verificar observabilidade**: abra `.logs/watch.log` para validar as entradas de cada passo, e monitore as métricas agregadas (latência total e número de tentativas OTP) conforme metas do manifesto.
+
+> 📌 O manifesto serve como contrato `contract-first` para qualquer agente MCP compatível, permitindo que outros squads implementem os mesmos fluxos em diferentes linguagens sem perder conformidade com o protocolo AP2.

--- a/ysh/domains/ap2/mcp/manifests/ap2.e2e360.suite.json
+++ b/ysh/domains/ap2/mcp/manifests/ap2.e2e360.suite.json
@@ -1,0 +1,370 @@
+{
+  "version": "1.0.0",
+  "domain": "ap2",
+  "updated_at": "2024-05-01T00:00:00Z",
+  "id": "ap2.e2e360.suite",
+  "name": "AP2 Payments E2E 360 Suite",
+  "description": "Suite MCP que descreve os fluxos ponta-a-ponta do protocolo AP2 para compras humanas e automáticas, incluindo credenciais, mandates e telemetria.",
+  "type": "orchestrator",
+  "mission": "Cobrir 360° dos fluxos de pagamento AP2 (intenção → carrinho → mandato → autenticação → recibo) com observabilidade e cenários de risco.",
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://github.com/google-agentic-commerce/ap2/v1",
+        "description": "Supports the Agent Payments Protocol.",
+        "required": true
+      }
+    ],
+    "contexts": [
+      "AP2/Payments",
+      "AP2/HumanPresent",
+      "AP2/HumanNotPresent",
+      "AP2/Credentials"
+    ]
+  },
+  "dependencies": {
+    "agents": [
+      {
+        "id": "shopping_agent",
+        "manifest": "./shopping_agent.json",
+        "role": "Shopping ADK responsável por coletar mandato de intenção, montar carrinho e conduzir usuário.",
+        "transport": ["A2A", "MCP"]
+      },
+      {
+        "id": "merchant_agent",
+        "manifest": "./merchant_agent.json",
+        "role": "Comerciante que mantém catálogo, carrinho, mandatos e delega pagamentos ao processador.",
+        "transport": ["A2A", "MCP"]
+      },
+      {
+        "id": "credentials_provider_agent",
+        "manifest": "./credentials_provider_agent.json",
+        "role": "Provedor de credenciais que tokeniza métodos, valida OTP e mantém contas confiáveis.",
+        "transport": ["A2A", "MCP"]
+      },
+      {
+        "id": "merchant_payment_processor_agent",
+        "manifest": "./merchant_payment_processor_agent.json",
+        "role": "Processador do comerciante responsável por desafios, autenticação e autorização final.",
+        "transport": ["A2A", "MCP"]
+      }
+    ],
+    "services": [
+      {
+        "name": "watch_log",
+        "type": "file",
+        "path": ".logs/watch.log",
+        "purpose": "Armazenar telemetria e instruções do fluxo AP2 para auditoria."
+      },
+      {
+        "name": "risk_memory_store",
+        "type": "in-memory",
+        "purpose": "Compartilhar risk_data entre shopping agent, merchant e processador."
+      }
+    ]
+  },
+  "tools": [
+    {
+      "name": "ap2.e2e.human_present_checkout",
+      "summary": "Executa o fluxo humano-presente ponta-a-ponta (mandatos → carrinho → tokenização → OTP → recibo).",
+      "input_schema": {
+        "type": "object",
+        "required": ["user", "cart", "presence_channel"],
+        "properties": {
+          "user": {
+            "type": "object",
+            "required": ["id", "display_name"],
+            "properties": {
+              "id": {"type": "string"},
+              "display_name": {"type": "string"},
+              "contact": {"type": "object"},
+              "risk_hints": {"type": "object"}
+            }
+          },
+          "cart": {
+            "type": "object",
+            "required": ["items"],
+            "properties": {
+              "cart_id": {"type": "string"},
+              "items": {
+                "type": "array",
+                "items": {"type": "object"}
+              },
+              "merchant": {"type": "string"},
+              "totals": {"type": "object"}
+            }
+          },
+          "shipping_address": {"type": "object"},
+          "presence_channel": {
+            "type": "string",
+            "enum": ["human_present"],
+            "description": "Identifica que o usuário está presente (OTP in-band)."
+          },
+          "payment_preferences": {"type": "object"},
+          "debug_mode": {"type": "boolean", "default": false}
+        }
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["receipt", "mandates", "events"],
+        "properties": {
+          "receipt": {"type": "object"},
+          "mandates": {
+            "type": "object",
+            "properties": {
+              "cart_mandate": {"type": "object"},
+              "payment_mandate": {"type": "object"}
+            }
+          },
+          "events": {"type": "array", "items": {"type": "string"}},
+          "watch_log_path": {"type": "string"},
+          "latency_ms": {"type": "number"}
+        }
+      },
+      "playbook": [
+        {
+          "step": 1,
+          "delegate": "shopping_agent.create_intent_mandate",
+          "description": "Gerar IntentMandate baseado no pedido natural do usuário e registrar no watch.log."
+        },
+        {
+          "step": 2,
+          "delegate": "merchant_agent.update_cart",
+          "description": "Criar/atualizar carrinho com totais e capturar impostos/frete."
+        },
+        {
+          "step": 3,
+          "delegate": "shopping_agent.checkout",
+          "description": "Solicitar métodos suportados, tokenizar credencial e coletar assinatura do CartMandate."
+        },
+        {
+          "step": 4,
+          "delegate": "merchant_agent.initiate_payment",
+          "description": "Encaminhar CartMandate e token ao processador, aguardando desafio OTP."
+        },
+        {
+          "step": 5,
+          "delegate": "merchant_payment_processor_agent.raise_challenge",
+          "description": "Emitir desafio OTP apropriado e registrar estado input_required."
+        },
+        {
+          "step": 6,
+          "delegate": "shopping_agent.handle_otp_challenge",
+          "description": "Coletar resposta OTP do usuário presente e enviar ao processador."
+        },
+        {
+          "step": 7,
+          "delegate": "merchant_payment_processor_agent.verify_challenge_response",
+          "description": "Validar resposta OTP, atualizar risk_data e preparar autorização."
+        },
+        {
+          "step": 8,
+          "delegate": "merchant_payment_processor_agent.complete_payment",
+          "description": "Finalizar pagamento com recibo e códigos de autorização."
+        },
+        {
+          "step": 9,
+          "delegate": "merchant_agent.dpc_finish",
+          "description": "Finalizar credencial digital e emitir eventos finais."
+        }
+      ],
+      "success_signals": [
+        "receipt.status == 'APPROVED'",
+        "events inclui 'ap2.checkout.completed.v1'",
+        "watch_log contém entries de todos os delegates"
+      ],
+      "failure_modes": [
+        "OTP inválido",
+        "shopping_agent_id não autorizado",
+        "PaymentMandate sem assinatura"
+      ]
+    },
+    {
+      "name": "ap2.e2e.human_absent_checkout",
+      "summary": "Fluxo humano-não-presente usando IntentMandate com TTL e callbacks.",
+      "input_schema": {
+        "type": "object",
+        "required": ["intent_mandate", "cart_blueprint", "callback"],
+        "properties": {
+          "intent_mandate": {"type": "object"},
+          "cart_blueprint": {"type": "object"},
+          "callback": {
+            "type": "object",
+            "required": ["uri"],
+            "properties": {
+              "uri": {"type": "string", "format": "uri"},
+              "auth": {"type": "object"}
+            }
+          },
+          "allowed_payment_networks": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "service_level_agreement_s": {"type": "number", "default": 600}
+        }
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["receipt", "callbacks"],
+        "properties": {
+          "receipt": {"type": "object"},
+          "callbacks": {"type": "array", "items": {"type": "object"}},
+          "mandates": {"type": "object"},
+          "events": {"type": "array", "items": {"type": "string"}}
+        }
+      },
+      "playbook": [
+        {
+          "step": 1,
+          "delegate": "shopping_agent.create_intent_mandate",
+          "description": "Registrar mandato com regras de presença e limites."
+        },
+        {
+          "step": 2,
+          "delegate": "merchant_agent.search_catalog",
+          "description": "Construir CartBlueprint respeitando restrições do mandato."
+        },
+        {
+          "step": 3,
+          "delegate": "merchant_agent.create_cart_mandate",
+          "description": "Assinar CartMandate com fail-safe (número de revisões)."
+        },
+        {
+          "step": 4,
+          "delegate": "merchant_agent.initiate_payment",
+          "description": "Acionar pagamento offline e registrar challenge/tokenization."
+        },
+        {
+          "step": 5,
+          "delegate": "merchant_payment_processor_agent.handle_payment_mandate",
+          "description": "Validar PaymentMandate recebido e preparar autorização diferida."
+        },
+        {
+          "step": 6,
+          "delegate": "merchant_payment_processor_agent.complete_payment",
+          "description": "Concluir transação e disparar callbacks configurados."
+        }
+      ],
+      "success_signals": [
+        "callbacks incluem estado final",
+        "mandates.payment_mandate.ttl respeitado",
+        "events inclui 'ap2.checkout.completed.v1' ou 'ap2.checkout.declined.v1'"
+      ],
+      "failure_modes": [
+        "Mandato expirado",
+        "Merchant não suporta rede solicitada",
+        "Callback 5xx repetido"
+      ]
+    },
+    {
+      "name": "ap2.e2e.enable_payment_method",
+      "summary": "Onboarding/tokenação de um método suportado pelo comerciante para destravar checkout futuro.",
+      "input_schema": {
+        "type": "object",
+        "required": ["user", "credential"],
+        "properties": {
+          "user": {
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+              "id": {"type": "string"},
+              "display_name": {"type": "string"}
+            }
+          },
+          "credential": {
+            "type": "object",
+            "required": ["scheme", "issuer"],
+            "properties": {
+              "scheme": {"type": "string", "enum": ["CARD", "PIX", "WALLET"]},
+              "issuer": {"type": "string"},
+              "last4": {"type": "string"},
+              "expiry": {"type": "string"}
+            }
+          },
+          "billing_address": {"type": "object"},
+          "risk_hints": {"type": "object"},
+          "debug_mode": {"type": "boolean", "default": false}
+        }
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["token", "mandate"],
+        "properties": {
+          "token": {"type": "string"},
+          "mandate": {"type": "object"},
+          "events": {"type": "array", "items": {"type": "string"}}
+        }
+      },
+      "playbook": [
+        {
+          "step": 1,
+          "delegate": "merchant_agent.update_cart",
+          "description": "Consultar merchant para validar aceitação da credencial."
+        },
+        {
+          "step": 2,
+          "delegate": "credentials_provider_agent.get_eligible_payment_methods",
+          "description": "Listar métodos existentes e identificar lacunas."
+        },
+        {
+          "step": 3,
+          "delegate": "credentials_provider_agent.create_payment_credential_token",
+          "description": "Tokenizar credencial com consentimento explícito do usuário."
+        },
+        {
+          "step": 4,
+          "delegate": "credentials_provider_agent.sign_payment_mandate",
+          "description": "Gerar PaymentMandate assinado e compartilhar com merchant/shopping agent."
+        }
+      ],
+      "success_signals": [
+        "token emitido e armazenado no credentials_provider",
+        "events inclui 'ap2.credential.tokenized.v1' quando aplicável",
+        "merchant atualiza risk_data com método habilitado"
+      ],
+      "failure_modes": [
+        "Esquema não suportado",
+        "Tokenização falhou",
+        "Consentimento ausente"
+      ]
+    }
+  ],
+  "events": {
+    "publishes": [
+      "ap2.intent.created.v1",
+      "ap2.cart.updated.v1",
+      "ap2.checkout.challenge.v1",
+      "ap2.checkout.completed.v1",
+      "ap2.checkout.declined.v1",
+      "ap2.credential.tokenized.v1"
+    ],
+    "consumes": [
+      "ap2.checkout.challenge_response.v1",
+      "ap2.checkout.retry_requested.v1"
+    ]
+  },
+  "observability": {
+    "logs": {
+      "watch_log": {
+        "path": ".logs/watch.log",
+        "format": "line-delimited json",
+        "retention": "per scenario"
+      }
+    },
+    "metrics": [
+      {
+        "name": "checkout_latency_ms",
+        "description": "Tempo total entre IntentMandate e recibo.",
+        "target": {"p95": 5000}
+      },
+      {
+        "name": "otp_retry_count",
+        "description": "Número de tentativas de OTP por transação.",
+        "target": {"max": 3}
+      }
+    ],
+    "traces": {
+      "propagation": "context_id compartilhado em events e logs"
+    }
+  }
+}

--- a/ysh/domains/origination-viabilidade/docs/WIRES_MCP.md
+++ b/ysh/domains/origination-viabilidade/docs/WIRES_MCP.md
@@ -1,5 +1,9 @@
 # Wires (A2A/MCP) — exemplos
 
-1) lead → viability → tariffs → economics
-2) benchmark distribuidora (INDGER + IASC + Utilities)
-Contratos de evento: `viability.requested.v1` → `viability.completed.v1`.
+1. lead → viability → tariffs → economics → recommendations (ver `pre.e2e360.suite.json`).
+2. benchmark distribuidora (INDGER + IASC + Utilities).
+3. gatilho de cross-sell AP2 ↔ PRE: `ap2.intent.created.v1` → `pre.e2e.orchestrate_pipeline` (gera `recommendation.bundle.created.v1`).
+
+Contratos de evento: `viability.requested.v1` → `viability.completed.v1` → `recommendation.bundle.created.v1`.
+
+O manifesto [`pre.e2e360.suite.json`](../mcp/manifests/pre.e2e360.suite.json) detalha cada delegate MCP (pvlib, tarifas, economics) e garante observabilidade por métricas de latência e erros NATS.

--- a/ysh/domains/origination-viabilidade/mcp/manifests/pre.e2e360.suite.json
+++ b/ysh/domains/origination-viabilidade/mcp/manifests/pre.e2e360.suite.json
@@ -1,0 +1,262 @@
+{
+  "version": "1.0.0",
+  "domain": "origination-viabilidade",
+  "updated_at": "2024-05-01T00:00:00Z",
+  "id": "pre.e2e360.suite",
+  "name": "PRE Origination E2E 360 Suite",
+  "description": "Orquestração MCP ponta-a-ponta do blueprint PRE (lead → viabilidade → recomendações) com delegações para serviços de dados e eventos.",
+  "type": "orchestrator",
+  "mission": "Garantir cobertura 360° da jornada PRE incluindo dados regulatórios, cálculos pvlib, economia e publicação de eventos NATS.",
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://github.com/google-agentic-commerce/ap2/v1",
+        "description": "Interoperabilidade com agentes AP2 para ofertas financeiras.",
+        "required": false
+      }
+    ],
+    "contexts": [
+      "YSH/Origination",
+      "YSH/Viability",
+      "YSH/Economics"
+    ]
+  },
+  "dependencies": {
+    "agents": [
+      {
+        "id": "pre_orchestrator_agent",
+        "manifest": "./pre_orchestrator_agent.json",
+        "role": "Agente que coordena skills PRE via FastAPI/NATS.",
+        "transport": ["MCP"]
+      },
+      {
+        "id": "solar_viability.agent",
+        "manifest": "./solar_viability.agent.json",
+        "role": "Executor pvlib/NASA para cálculos solares.",
+        "transport": ["MCP", "A2A"]
+      },
+      {
+        "id": "aneel.tariffs.agent",
+        "manifest": "./aneel.tariffs.agent.json",
+        "role": "Fornecedor de componentes tarifários TE/TUSD.",
+        "transport": ["MCP"]
+      },
+      {
+        "id": "aneel.kpis.agent",
+        "manifest": "./aneel.kpis.agent.json",
+        "role": "Consulta KPIs regulatórios para benchmarking.",
+        "transport": ["MCP"]
+      },
+      {
+        "id": "aneel.utilities.agent",
+        "manifest": "./aneel.utilities.agent.json",
+        "role": "Catálogo de distribuidoras, tarifas e metadados.",
+        "transport": ["MCP"]
+      }
+    ],
+    "services": [
+      {
+        "name": "nats_bus",
+        "type": "messaging",
+        "protocol": "nats://",
+        "topics": [
+          "viability.requested.v1",
+          "viability.completed.v1",
+          "recommendation.bundle.created.v1"
+        ]
+      }
+    ]
+  },
+  "tools": [
+    {
+      "name": "pre.e2e.orchestrate_pipeline",
+      "summary": "Executa toda a jornada PRE com emissão de eventos e geração de ofertas Base/Plus/Pro.",
+      "input_schema": {
+        "type": "object",
+        "required": ["lead", "consumption"],
+        "properties": {
+          "lead": {
+            "type": "object",
+            "required": ["lead_id", "name", "email", "phone", "consent"],
+            "properties": {
+              "lead_id": {"type": "string"},
+              "name": {"type": "string"},
+              "email": {"type": "string", "format": "email"},
+              "phone": {"type": "string"},
+              "consent": {"type": "boolean"},
+              "source": {"type": "string"},
+              "address": {"type": "object"},
+              "geo": {"type": "object", "properties": {"lat": {"type": "number"}, "lon": {"type": "number"}}}
+            }
+          },
+          "consumption": {
+            "type": "object",
+            "required": ["tariff_group", "consumer_class"],
+            "properties": {
+              "tariff_group": {"type": "string"},
+              "consumer_class": {"type": "string"},
+              "consumer_subclass": {"type": "string"},
+              "uc_type": {"type": "string"},
+              "annual_kwh": {"type": "number"},
+              "peak_share_pct": {"type": "number"}
+            }
+          },
+          "preferences": {"type": "object"},
+          "debug_mode": {"type": "boolean", "default": false}
+        }
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["recommendations", "events"],
+        "properties": {
+          "recommendations": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Ofertas Base/Plus/Pro com indicadores financeiros."
+          },
+          "events": {"type": "array", "items": {"type": "string"}},
+          "viability": {"type": "object"},
+          "tariff_profile": {"type": "object"},
+          "economics": {"type": "object"}
+        }
+      },
+      "playbook": [
+        {
+          "step": 1,
+          "delegate": "pre_orchestrator_agent.create_update_lead",
+          "description": "Persistir/atualizar dados do lead com consentimento LGPD."
+        },
+        {
+          "step": 2,
+          "delegate": "pre_orchestrator_agent.classify_consumer",
+          "description": "Definir classe, subclasse e tipo de UC a partir do consumo."
+        },
+        {
+          "step": 3,
+          "delegate": "pre_orchestrator_agent.select_modality",
+          "description": "Escolher modalidade de geração e publicar evento viability.requested.v1."
+        },
+        {
+          "step": 4,
+          "delegate": "solar_viability.agent.viability.compute",
+          "description": "Calcular geração (kWh/ano, PR) com pvlib e NASA POWER."
+        },
+        {
+          "step": 5,
+          "delegate": "aneel.tariffs.agent.aneel.tariffs.profile.build",
+          "description": "Construir tariff_profile para perfil do cliente."
+        },
+        {
+          "step": 6,
+          "delegate": "solar_viability.agent.economics.evaluate",
+          "description": "Calcular ROI, Payback e TIR com base em capex/opex."
+        },
+        {
+          "step": 7,
+          "delegate": "pre_orchestrator_agent.generate_recommendations",
+          "description": "Gerar pacotes Base/Plus/Pro e emitir recommendation.bundle.created.v1."
+        }
+      ],
+      "success_signals": [
+        "events inclui 'viability.completed.v1'",
+        "recommendations possui 3 ofertas",
+        "economics.tir_pct > 0"
+      ],
+      "failure_modes": [
+        "Dados de lead incompletos",
+        "Erro de rede em NASA POWER",
+        "Tarifa não encontrada para distribuidora"
+      ]
+    },
+    {
+      "name": "pre.e2e.evaluate_site",
+      "summary": "Atalho MCP para validar rapidamente um projeto solar usando ferramentas delegadas.",
+      "input_schema": {
+        "type": "object",
+        "required": ["lat", "lon", "tariff_profile", "capex", "opex"],
+        "properties": {
+          "lat": {"type": "number"},
+          "lon": {"type": "number"},
+          "tilt_deg": {"type": "number", "default": 20},
+          "azimuth_deg": {"type": "number", "default": 180},
+          "system_loss_fraction": {"type": "number", "default": 0.14},
+          "tariff_profile": {"type": "object"},
+          "capex": {"type": "number"},
+          "opex": {"type": "number"},
+          "lifetime_years": {"type": "number", "default": 25}
+        }
+      },
+      "output_schema": {
+        "type": "object",
+        "required": ["viability", "economics"],
+        "properties": {
+          "viability": {"type": "object"},
+          "economics": {"type": "object"},
+          "events": {"type": "array", "items": {"type": "string"}}
+        }
+      },
+      "playbook": [
+        {
+          "step": 1,
+          "delegate": "solar_viability.agent.viability.compute",
+          "description": "Executar cadeia pvlib (irradiância, performance, PR)."
+        },
+        {
+          "step": 2,
+          "delegate": "solar_viability.agent.economics.evaluate",
+          "description": "Calcular indicadores financeiros e série de cashflow."
+        },
+        {
+          "step": 3,
+          "delegate": "pre_orchestrator_agent.emit_event",
+          "description": "Publicar eventos viability.completed.v1 com payload agregado."
+        }
+      ],
+      "success_signals": [
+        "viability.pr calculado",
+        "economics.roi_pct",
+        "events contém 'viability.completed.v1'"
+      ],
+      "failure_modes": [
+        "Latitude/Longitude inválidos",
+        "Capex <= 0",
+        "Erro NATS ao publicar evento"
+      ]
+    }
+  ],
+  "events": {
+    "publishes": [
+      "lead.captured.v1",
+      "viability.requested.v1",
+      "viability.completed.v1",
+      "recommendation.bundle.created.v1"
+    ],
+    "consumes": [
+      "viability.requested.v1",
+      "ap2.intent.created.v1"
+    ]
+  },
+  "observability": {
+    "logs": {
+      "pre_orchestrator": {
+        "path": "domains/origination-viabilidade/apps/pre_orchestrator/.logs/server.log",
+        "format": "structured-json"
+      }
+    },
+    "metrics": [
+      {
+        "name": "viability_latency_ms",
+        "description": "Tempo entre request e resposta do serviço pvlib.",
+        "target": {"p95": 3000}
+      },
+      {
+        "name": "nats_publish_errors",
+        "description": "Número de falhas ao publicar eventos PRE.",
+        "target": {"max": 0}
+      }
+    ],
+    "traces": {
+      "propagation": "context_id herdado do orchestrate_pre_process"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an AP2 payments E2E 360 MCP manifest describing human-present, human-absent and credential onboarding playbooks
- define a PRE domain E2E 360 MCP manifest covering lead orchestration, viability, tariffs and economics
- document how to run the AP2 E2E suite and update MCP wiring guidance to reference the new manifests

## Testing
- not run (documentation and manifest updates)

------
https://chatgpt.com/codex/tasks/task_e_68d1111a8dd08332b6fb46237c221507