### PR TITLE
Add FastAPI service for MMGD provider portals

### DIFF
--- a/ysh/domains/origination-viabilidade/apps/gd_providers_api/gd_providers_api/__init__.py
+++ b/ysh/domains/origination-viabilidade/apps/gd_providers_api/gd_providers_api/__init__.py
@@ -1,0 +1,5 @@
+"""MMGD providers FastAPI application package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/ysh/domains/origination-viabilidade/apps/gd_providers_api/gd_providers_api/data.py
+++ b/ysh/domains/origination-viabilidade/apps/gd_providers_api/gd_providers_api/data.py
@@ -1,0 +1,329 @@
+"""Static dataset describing MMGD provider submission portals."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .schemas import ProvidersDataset
+
+
+RAW_DATA: Dict = {
+    "api": "br.gd.providers",
+    "version": "2025-09-20",
+    "updated_at": "2025-09-20",
+    "global": {
+        "aneel_forms_page": "https://www.gov.br/aneel/pt-br/centrais-de-conteudos/formularios/geracao-distribuida",
+        "legal_refs": ["REN ANEEL 1000/2021", "REN ANEEL 1059/2023", "Lei 14.300/2022"],
+    },
+    "providers": [
+        {
+            "id": "enel-rj",
+            "name": "Enel Distribuição Rio",
+            "group": "Enel",
+            "states": ["RJ"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "portal": "https://www.eneldistribuicao.com.br/PortalGD/ENELRJ/Acessante/",
+                    "basic_form": "https://www.eneldistribuicao.com.br/PortalGD/ENELRJ/Acessante/pages/formularioBasico.jsf",
+                    "manual": "https://www.enel.com.br/content/dam/enel-br/one-hub-brasil---2018/corporativo-e-governo-/geracao_distribuida/AM037-20C-MANUAL-ACESSANTE-PORTAL-GERACAO-DISTRIBUIDA-20200923-FIM.pdf",
+                },
+                "requirements": {"login_required": False, "captcha": False},
+            },
+            "docs": {
+                "howto": [
+                    "https://www.enel.com.br/pt/Corporativo_e_Governo/Geracao_Distribuida.html"
+                ]
+            },
+        },
+        {
+            "id": "enel-ce",
+            "name": "Enel Distribuição Ceará",
+            "group": "Enel",
+            "states": ["CE"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "portal": "https://www.eneldistribuicao.com.br/PortalGD/ENELCE/Acessante/",
+                    "basic_form": "https://www.eneldistribuicao.com.br/PortalGD/ENELCE/Acessante/pages/formularioBasico.jsf",
+                },
+                "requirements": {"login_required": False, "captcha": False},
+            },
+        },
+        {
+            "id": "light-rj",
+            "name": "Light",
+            "group": "Light",
+            "states": ["RJ"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "gd_page": "https://www.light.com.br/SitePages/page-geracao-distribuida.aspx",
+                    "portal_login": "https://agenciavirtual.light.com.br/Portal/inicio.aspx",
+                    "downloads": "https://www.light.com.br/Documentos%20Compartilhados/Geracao-Distribuida-Arquivos-Relacionados/LIGHT_GERACAO_DISTRIBUIDA_site.pdf",
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "neoenergia-elektro-sp",
+            "name": "Neoenergia Elektro",
+            "group": "Neoenergia",
+            "states": ["SP", "MS"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "portal": "https://gdneoenergiaelektro.neoenergia.com/",
+                    "help_flow": "https://www.neoenergia.com/web/sp/seu-negocio/geracao-distribuida",
+                },
+                "requirements": {
+                    "login_required": True,
+                    "captcha": True,
+                    "captcha_vendor_hint": "BotDetect",
+                },
+            },
+        },
+        {
+            "id": "neoenergia-coelba-ba",
+            "name": "Neoenergia Coelba",
+            "group": "Neoenergia",
+            "states": ["BA"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "portal": "https://gdneoenergiacoelba.neoenergia.com/",
+                    "signup": "https://gdneoenergiacoelba.neoenergia.com/cadastrarUsuario.jsf",
+                },
+                "requirements": {"login_required": True, "captcha": True},
+            },
+        },
+        {
+            "id": "neoenergia-cosern-rn",
+            "name": "Neoenergia Cosern",
+            "group": "Neoenergia",
+            "states": ["RN"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {"portal": "https://gdneoenergiacosern.neoenergia.com/"},
+                "requirements": {"login_required": True, "captcha": True},
+            },
+        },
+        {
+            "id": "neoenergia-pernambuco-pe",
+            "name": "Neoenergia Pernambuco (CELPE)",
+            "group": "Neoenergia",
+            "states": ["PE"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "portal": "https://gdneoenergiapernambuco.neoenergia.com/",
+                    "landing": "https://www.neoenergia.com/web/pernambuco/seu-negocio/geracao-distribuida",
+                },
+                "requirements": {"login_required": True, "captcha": True},
+            },
+        },
+        {
+            "id": "cpfl-sp",
+            "name": "CPFL (Paulista/Piratininga e outras)",
+            "group": "CPFL",
+            "states": ["SP", "RS"],
+            "submission": {
+                "type": "web_portal_docs",
+                "urls": {
+                    "service_page": "https://www.cpfl.com.br/mini-e-microgeracao",
+                    "norma_tecnica": "https://www.cpfl.com.br/sites/cpfl/files/2021-12/GED-15303.pdf",
+                    "form_anexo_e_docx": "https://www.cpfl.com.br/sites/cpfl/files/2024-08/Formul%C3%A1rio%20%28Anexo%20E%20-%20GED%2015303%29.docx",
+                    "form_anexo_f_xlsx": "https://www.cpfl.com.br/sites/cpfl/files/2025-01/Formul%C3%A1rio%20Anexo%20F%20-%20GED%2015303.xlsx",
+                    "cartilha": "https://www.cpfl.com.br/sites/cpfl/files/2024-10/CARTILHA%20GD%20CPFL.pdf",
+                },
+                "requirements": {"login_required": False, "captcha": False},
+            },
+        },
+        {
+            "id": "cemig-mg",
+            "name": "Cemig",
+            "group": "Cemig",
+            "states": ["MG"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "manual_gd": "https://www.cemig.com.br/manual-de-geracao-distribuida/",
+                    "portal_login": "https://atende.cemig.com.br/Login",
+                    "norma_nd530_pdf": "https://www.cemig.com.br/wp-content/uploads/2020/07/ND.5.30.pdf",
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "celesc-sc",
+            "name": "Celesc",
+            "group": "Celesc",
+            "states": ["SC"],
+            "submission": {
+                "type": "web_portal_docs",
+                "urls": {
+                    "service_page": "https://www.celesc.com.br/conexao-de-micro-ou-minigerador",
+                    "instruicao_i4320004_pdf": "https://www.celesc.com.br/arquivos/normas-tecnicas/conexao-centrais-geradoras/conexao-micro-mini-geradores-out2020.pdf",
+                    "guia_portal_tecnico_pdf": "https://www.celesc.com.br/images/central-ajuda/micro-mini-geracao/Guia-cadastro-de-projetos-Portal-Tecnico.pdf",
+                },
+                "requirements": {"login_required": False, "captcha": False},
+            },
+        },
+        {
+            "id": "edp-es-sp",
+            "name": "EDP (ES e SP)",
+            "group": "EDP",
+            "states": ["ES", "SP"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "landing": "https://www.edp.com.br/micro-e-mini-geracao/",
+                    "form_mmgd": "https://www.edp.com.br/micro-e-mini-geracao/formulario-mmgd-solicitacao-de-acesso",
+                    "agencia_login": "https://www.edponline.com.br/para-sua-casa/login",
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "equatorial-go",
+            "name": "Equatorial Goiás",
+            "group": "Equatorial",
+            "states": ["GO"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "landing": "https://go.equatorialenergia.com.br/sua-conta/geracao-distribuida/",
+                    "parecer_de_acesso": "https://go.equatorialenergia.com.br/sua-conta/geracao-distribuida/parecer-de-acesso/",
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "equatorial-pi",
+            "name": "Equatorial Piauí",
+            "group": "Equatorial",
+            "states": ["PI"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "landing": "https://pi.equatorialenergia.com.br/sua-conta/mini-e-micro-geracao/",
+                    "parecer_de_acesso": "https://pi.equatorialenergia.com.br/sua-conta/mini-e-micro-geracao/parecer-de-acesso/",
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "equatorial-ma",
+            "name": "Equatorial Maranhão",
+            "group": "Equatorial",
+            "states": ["MA"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "landing": "https://ma.equatorialenergia.com.br/sua-conta/mini-e-micro-geracao/",
+                    "parecer_de_acesso": "https://ma.equatorialenergia.com.br/sua-conta/mini-e-micro-geracao/parecer-de-acesso/",
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "equatorial-pa",
+            "name": "Equatorial Pará",
+            "group": "Equatorial",
+            "states": ["PA"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "landing": "https://pa.equatorialenergia.com.br/sua-conta/mini-e-micro-geracao/"
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "equatorial-ap",
+            "name": "Equatorial Amapá (CEA)",
+            "group": "Equatorial",
+            "states": ["AP"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "landing": "https://ap.equatorialenergia.com.br/sua-conta/mini-e-micro-geracao/"
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "energisa-group",
+            "name": "Energisa (Grupo – múltiplos estados)",
+            "group": "Energisa",
+            "states": ["AC", "RO", "TO", "PB", "SE", "MT", "MS", "MG", "RJ", "SP", "PR"],
+            "submission": {
+                "type": "web_portal_docs",
+                "urls": {
+                    "landing": "https://www.energisa.com.br/para-sua-casa/servicos/outros-servicos/geracao-distribuida",
+                    "faq_docs": "https://ajuda.energisa.com.br/categoria/micro-minigeracao/",
+                    "ndu_015_pdf": "https://www.energisa.com.br/sites/energisa/files/media/documents/2025-02/NDU%20015%20-%20Crit%C3%A9rios%20para%20a%20Conex%C3%A3o%20em%20M%C3%A9dia%20Tens%C3%A3o%20de%20Acessantes%20de%20Gera%C3%A7%C3%A3o%20Distribu%C3%ADda%20ao%20Sistema%20de%20Distribui%C3%A7%C3%A3o_.pdf",
+                },
+                "requirements": {"login_required": "case", "captcha": False},
+                "notes": "Formulários oficiais ficam nos anexos das NDU-013/015; checar por distribuidora do grupo.",
+            },
+        },
+        {
+            "id": "copel-pr",
+            "name": "Copel",
+            "group": "Copel",
+            "states": ["PR"],
+            "submission": {
+                "type": "web_portal_docs",
+                "urls": {
+                    "vistoria_info": "https://www.copel.com/site/fornecedores-e-parceiros/geracao-distribuida/",
+                    "vistoria_news": "https://www.parana.pr.gov.br/aen/Noticia/Copel-oferece-vistoria-virtual-para-ligacoes-de-imoveis-novos",
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "amazonas-energia",
+            "name": "Amazonas Energia",
+            "group": "Amazonas Energia",
+            "states": ["AM"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "landing": "https://website.amazonasenergia.com/informacoes/micro-minigeracao-distribuida/",
+                    "proger_login": "https://proger.amazonasenergia.com/",
+                    "manual_proger": "https://website.amazonasenergia.com/wp-content/uploads/2022/05/Manual-Sistema-Amazonas-Energia-vers-02.pdf",
+                },
+                "requirements": {"login_required": True, "captcha": False},
+            },
+        },
+        {
+            "id": "roraima-energia",
+            "name": "Roraima Energia",
+            "group": "Roraima Energia",
+            "states": ["RR"],
+            "submission": {
+                "type": "web_portal",
+                "urls": {
+                    "conexao_facil": "https://conexaofacil.roraimaenergia.com.br/",
+                    "mmgd_page": "https://www.roraimaenergia.com.br/nossos-servicos/micro-minigeracao-distribuida/",
+                    "proger_login": "https://proger.roraimaenergia.com.br/",
+                },
+                "requirements": {"login_required": True, "captcha": False},
+                "notes": "Desde 11/11/2024, microgeração via Conexão Fácil (GDIS).",
+            },
+        },
+    ],
+}
+
+
+def _validate_dataset(raw: Dict) -> ProvidersDataset:
+    """Validate the raw data using Pydantic, supporting multiple versions."""
+
+    if hasattr(ProvidersDataset, "model_validate"):
+        return ProvidersDataset.model_validate(raw)  # type: ignore[attr-defined]
+    return ProvidersDataset.parse_obj(raw)  # pragma: no cover
+
+
+DATASET: ProvidersDataset = _validate_dataset(RAW_DATA)
+PROVIDERS_BY_ID = {provider.id: provider for provider in DATASET.providers}

--- a/ysh/domains/origination-viabilidade/apps/gd_providers_api/gd_providers_api/main.py
+++ b/ysh/domains/origination-viabilidade/apps/gd_providers_api/gd_providers_api/main.py
@@ -1,0 +1,120 @@
+"""FastAPI application that exposes the MMGD providers dataset."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException, Query
+
+from .data import DATASET, PROVIDERS_BY_ID
+from .schemas import DatasetMetadata, GlobalInfo, Provider, SubmissionInfo
+
+
+def _filter_by_state(providers: List[Provider], state: str) -> List[Provider]:
+    state_upper = state.upper()
+    return [
+        provider
+        for provider in providers
+        if any(candidate.upper() == state_upper for candidate in provider.states)
+    ]
+
+
+def _filter_by_group(providers: List[Provider], group: str) -> List[Provider]:
+    group_lower = group.lower()
+    return [
+        provider for provider in providers if provider.group.lower() == group_lower
+    ]
+
+
+def _filter_by_submission_type(
+    providers: List[Provider], submission_type: str
+) -> List[Provider]:
+    submission_type_lower = submission_type.lower()
+    return [
+        provider
+        for provider in providers
+        if provider.submission.type.lower() == submission_type_lower
+    ]
+
+
+app = FastAPI(
+    title="MMGD Providers API",
+    version=DATASET.version,
+    description=(
+        "Catálogo em FastAPI dos portais públicos de homologação MMGD por"
+        " distribuidora, conforme bootstrap fornecido."
+    ),
+)
+
+
+@app.get("/metadata", response_model=DatasetMetadata, tags=["dataset"])
+def get_metadata() -> DatasetMetadata:
+    """Return API metadata and simple statistics."""
+
+    return DatasetMetadata(
+        api=DATASET.api,
+        version=DATASET.version,
+        updated_at=DATASET.updated_at,
+        provider_count=len(DATASET.providers),
+    )
+
+
+@app.get("/global", response_model=GlobalInfo, tags=["dataset"])
+def get_global_info() -> GlobalInfo:
+    """Return dataset-wide ANEEL references and legal norms."""
+
+    return DATASET.global_
+
+
+@app.get("/providers", response_model=List[Provider], tags=["providers"])
+def list_providers(
+    state: Optional[str] = Query(
+        default=None,
+        description="Filter providers by federative unit (sigla do estado).",
+        min_length=2,
+        max_length=2,
+    ),
+    group: Optional[str] = Query(
+        default=None, description="Filter providers by holding/group name."
+    ),
+    submission_type: Optional[str] = Query(
+        default=None,
+        description="Filter by submission.type (ex.: web_portal, web_portal_docs).",
+    ),
+) -> List[Provider]:
+    """Return the list of providers, optionally filtered by query parameters."""
+
+    providers: List[Provider] = list(DATASET.providers)
+
+    if state:
+        providers = _filter_by_state(providers, state)
+    if group:
+        providers = _filter_by_group(providers, group)
+    if submission_type:
+        providers = _filter_by_submission_type(providers, submission_type)
+
+    return providers
+
+
+@app.get("/providers/{provider_id}", response_model=Provider, tags=["providers"])
+def get_provider(provider_id: str) -> Provider:
+    """Return a single provider by its identifier."""
+
+    provider = PROVIDERS_BY_ID.get(provider_id)
+    if not provider:
+        raise HTTPException(status_code=404, detail="Provider not found")
+    return provider
+
+
+@app.get(
+    "/providers/{provider_id}/submission",
+    response_model=SubmissionInfo,
+    tags=["providers"],
+)
+def get_provider_submission(provider_id: str) -> SubmissionInfo:
+    """Return only the submission block for a provider."""
+
+    provider = PROVIDERS_BY_ID.get(provider_id)
+    if not provider:
+        raise HTTPException(status_code=404, detail="Provider not found")
+    return provider.submission

--- a/ysh/domains/origination-viabilidade/apps/gd_providers_api/gd_providers_api/schemas.py
+++ b/ysh/domains/origination-viabilidade/apps/gd_providers_api/gd_providers_api/schemas.py
@@ -1,0 +1,90 @@
+"""Pydantic models describing the MMGD providers dataset."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+try:  # pragma: no cover - compatibility shim for Pydantic v1.
+    from pydantic import ConfigDict
+except ImportError:  # pragma: no cover
+    ConfigDict = None  # type: ignore[misc]
+
+
+class SubmissionRequirements(BaseModel):
+    """Authentication and anti-bot requirements for a provider portal."""
+
+    login_required: Optional[Union[bool, str]] = Field(
+        default=None,
+        description=(
+            "Indicates whether authentication is required. Some providers"
+            " report special cases as strings."
+        ),
+    )
+    captcha: Optional[Union[bool, str]] = Field(
+        default=None, description="Whether a CAPTCHA challenge is present."
+    )
+    captcha_vendor_hint: Optional[str] = Field(
+        default=None, description="Optional hint about the CAPTCHA technology."
+    )
+
+
+class SubmissionInfo(BaseModel):
+    """Information about how to submit distributed generation requests."""
+
+    type: str
+    urls: Dict[str, str]
+    requirements: SubmissionRequirements
+    notes: Optional[str] = None
+
+
+class DocsInfo(BaseModel):
+    """Additional documentation links."""
+
+    howto: Optional[List[str]] = None
+
+
+class Provider(BaseModel):
+    """Represents a distribution utility that accepts MMGD requests."""
+
+    id: str
+    name: str
+    group: str
+    states: List[str]
+    submission: SubmissionInfo
+    docs: Optional[DocsInfo] = None
+    notes: Optional[str] = None
+
+
+class GlobalInfo(BaseModel):
+    """Dataset-wide references applicable to all providers."""
+
+    aneel_forms_page: str
+    legal_refs: List[str]
+
+
+class ProvidersDataset(BaseModel):
+    """Full dataset published by the user."""
+
+    api: str
+    version: str
+    updated_at: date
+    global_: GlobalInfo = Field(alias="global")
+    providers: List[Provider]
+
+    if ConfigDict is not None:  # pragma: no branch
+        model_config = ConfigDict(populate_by_name=True)
+    else:  # pragma: no cover
+        class Config:  # type: ignore[no-redef]
+            allow_population_by_field_name = True
+
+
+class DatasetMetadata(BaseModel):
+    """Summary statistics about the dataset."""
+
+    api: str
+    version: str
+    updated_at: date
+    provider_count: int

--- a/ysh/domains/origination-viabilidade/apps/gd_providers_api/pyproject.toml
+++ b/ysh/domains/origination-viabilidade/apps/gd_providers_api/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "gd-providers-api"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn>=0.30",
+    "pydantic>=1.10,<3",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]

--- a/ysh/domains/origination-viabilidade/apps/gd_providers_api/tests/test_api.py
+++ b/ysh/domains/origination-viabilidade/apps/gd_providers_api/tests/test_api.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gd_providers_api.main import app
+
+client = TestClient(app)
+
+
+def test_metadata_endpoint_returns_dataset_info() -> None:
+    response = client.get("/metadata")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["api"] == "br.gd.providers"
+    assert payload["version"] == "2025-09-20"
+    assert payload["provider_count"] == 20
+
+
+def test_list_providers_filters_by_state() -> None:
+    response = client.get("/providers", params={"state": "RJ"})
+    assert response.status_code == 200
+    providers = response.json()
+    assert any(provider["id"] == "enel-rj" for provider in providers)
+    assert all("RJ" in provider["states"] for provider in providers)
+
+
+def test_retrieve_specific_provider() -> None:
+    response = client.get("/providers/neoenergia-coelba-ba")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["group"] == "Neoenergia"
+    assert payload["submission"]["requirements"]["captcha"] is True
+
+
+def test_submission_type_filter() -> None:
+    response = client.get("/providers", params={"submission_type": "web_portal_docs"})
+    assert response.status_code == 200
+    providers = response.json()
+    assert providers
+    assert all(provider["submission"]["type"] == "web_portal_docs" for provider in providers)
+
+
+def test_provider_not_found_returns_404() -> None:
+    response = client.get("/providers/unknown-provider")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Provider not found"


### PR DESCRIPTION
## Summary
- add a dedicated FastAPI service that publishes the MMGD provider bootstrap dataset as typed endpoints
- implement dataset filters for state, group, and submission type plus detailed provider/submission lookups
- cover the new API with FastAPI TestClient-based tests and bundle project metadata for standalone use

## Testing
- PYTHONPATH=ysh/domains/origination-viabilidade/apps/gd_providers_api PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest ysh/domains/origination-viabilidade/apps/gd_providers_api/tests/test_api.py


------
https://chatgpt.com/codex/tasks/task_e_68d129abd5388332bf8cf64e9e550ed7