### PR TITLE
feat(origination): enrich sizing output and stabilize tests

### DIFF
--- a/ysh/domains/origination-viabilidade/apps/origination_api/app/routers/leads.py
+++ b/ysh/domains/origination-viabilidade/apps/origination_api/app/routers/leads.py
@@ -16,8 +16,8 @@ from app.schemas.leads import (
     SizingIn,
     SizingOut,
 )
-from app.services.recommendations import TIERS, build_bundle
-from app.services.sizing import sizing_summary
+from app.services.recommendations import PROJECT_BANDS, TIERS, build_bundle
+from app.services.sizing import choose_band, sizing_summary
 
 router = APIRouter()
 
@@ -153,6 +153,7 @@ async def size_lead(
         "load_profile": features.load_profile,
     }
     summary = sizing_summary(feature_payload, tier["factor"])
+    band_code, _ = choose_band(summary["kwp"], PROJECT_BANDS)
     now = datetime.now(timezone.utc).isoformat()
     await publish(
         SUBJECTS["sized"],
@@ -167,6 +168,7 @@ async def size_lead(
     )
     return {
         "lead_id": lead_id,
+        "band_code": band_code,
         "kwp": summary["kwp"],
         "expected_kwh_year": summary["expected_kwh_year"],
         "pr": summary["pr"],

--- a/ysh/domains/origination-viabilidade/apps/origination_api/app/schemas/leads.py
+++ b/ysh/domains/origination-viabilidade/apps/origination_api/app/schemas/leads.py
@@ -45,6 +45,7 @@ class SizingIn(BaseModel):
 
 class SizingOut(BaseModel):
     lead_id: str
+    band_code: str
     kwp: float
     expected_kwh_year: float
     pr: float

--- a/ysh/domains/origination-viabilidade/apps/origination_api/app/services/recommendations.py
+++ b/ysh/domains/origination-viabilidade/apps/origination_api/app/services/recommendations.py
@@ -1,15 +1,18 @@
 import uuid
 from collections.abc import Iterable
+from pathlib import Path
 
 import yaml
 
 from app.services.sizing import choose_band, sizing_summary
 
-with open("configs/project_size_bands.yaml", "r", encoding="utf-8") as fp:
+CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs"
+
+with open(CONFIG_DIR / "project_size_bands.yaml", "r", encoding="utf-8") as fp:
     PROJECT_BANDS = yaml.safe_load(fp)["bands"]
-with open("configs/recommendation_tiers.yaml", "r", encoding="utf-8") as fp:
+with open(CONFIG_DIR / "recommendation_tiers.yaml", "r", encoding="utf-8") as fp:
     TIERS = {tier["code"]: tier for tier in yaml.safe_load(fp)["tiers"]}
-with open("configs/upsell_rules.yaml", "r", encoding="utf-8") as fp:
+with open(CONFIG_DIR / "upsell_rules.yaml", "r", encoding="utf-8") as fp:
     UPSELL = yaml.safe_load(fp)["rules"]
 
 

--- a/ysh/domains/origination-viabilidade/apps/origination_api/tests/test_health.py
+++ b/ysh/domains/origination-viabilidade/apps/origination_api/tests/test_health.py
@@ -1,12 +1,17 @@
-from httpx import AsyncClient
+import os
+
 import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
 
 from app.main import app
 
 
 @pytest.mark.asyncio
 async def test_health() -> None:
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get("/health")
     assert response.status_code == 200
     assert response.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- include band selection in the sizing API response and reuse configured project bands
- resolve configuration path loading for recommendation assets so imports work from any CWD
- modernize the health check test to set up an in-memory database URL and use httpx's ASGI transport

## Testing
- `pytest ysh/domains/origination-viabilidade/apps/origination_api/tests/test_health.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1452e7954833284a7b7ea602f582b