### PR TITLE
Add 3D tiles Next frontend and solar FastAPI service

### DIFF
--- a/ysh/domains/geo_solar/README.md
+++ b/ysh/domains/geo_solar/README.md
@@ -1,0 +1,24 @@
+# Geo Solar API
+
+Serviço FastAPI que calcula posição solar (azimute/elevação) usando a biblioteca `solposx`.
+
+## Instalação
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Execução
+
+```bash
+uvicorn app:app --host 0.0.0.0 --port 8000
+```
+
+Para desenvolvimento com HTTPS forneça `--ssl-keyfile` e `--ssl-certfile`.
+
+## Endpoints
+
+- `GET /healthz`
+- `GET /solpos?lat=...&lon=...&iso=...`

--- a/ysh/domains/geo_solar/app.py
+++ b/ysh/domains/geo_solar/app.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from solposx import solar_position
+
+app = FastAPI(title="YSH Solar API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://localhost:3000", "http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, bool]:
+    return {"ok": True}
+
+
+@app.get("/solpos")
+def solpos(lat: float, lon: float, iso: str) -> dict[str, float | str]:
+    """Calcula azimute e elevação solar para coordenadas e horário informados."""
+
+    try:
+        dt = datetime.fromisoformat(iso)
+    except ValueError as exc:
+        return {"error": f"Invalid ISO datetime: {exc}"}
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+
+    solar = solar_position(latitude=lat, longitude=lon, timestamp=dt)
+    return {"azimuth_deg": solar.azimuth, "elevation_deg": solar.elevation}

--- a/ysh/domains/geo_solar/requirements.txt
+++ b/ysh/domains/geo_solar/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+solposx==0.1.7

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/.env.local.example
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/.env.local.example
@@ -1,0 +1,13 @@
+# URL pública do tileset (pode apontar para o proxy /api/tiles/...)
+NEXT_PUBLIC_TILESET_URL="https://YOUR_TILES_HOST/path/to/tileset.json"
+
+# Backend FastAPI (serviço solar)
+SOLAR_API_BASE="https://localhost:8000"
+
+# Host de tiles para o proxy (sem https://)
+TILES_HOST="cdn.example.com"
+
+# Valores default para o painel solar
+DEFAULT_LAT="-23.5505"
+DEFAULT_LON="-46.6333"
+DEFAULT_ISO="2025-09-21T13:00:00Z"

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/.gitignore
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/.gitignore
@@ -1,0 +1,13 @@
+# Next.js
+.next/
+out/
+
+# dependencies
+node_modules/
+
+# env
+.env.local
+.env*.local
+
+# misc
+.DS_Store

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/README.md
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/README.md
@@ -1,0 +1,56 @@
+# Origination Geo Frontend
+
+Frontend Next.js 15 para visualizar tiles 3D (OGC 3D Tiles) com iluminação solar dinâmica.
+
+## Instalação
+
+```bash
+pnpm install
+pnpm add three 3d-tiles-renderer
+```
+
+As dependências principais já estão declaradas em `package.json`. O comando `pnpm add` é necessário apenas se desejar atualizar manualmente `three` ou `3d-tiles-renderer`.
+
+## Variáveis de ambiente
+
+Crie um arquivo `.env.local` baseado em `.env.local.example`:
+
+```env
+NEXT_PUBLIC_TILESET_URL="https://YOUR_TILES_HOST/path/to/tileset.json"
+SOLAR_API_BASE="https://localhost:8000"
+TILES_HOST="cdn.example.com"
+DEFAULT_LAT="-23.5505"
+DEFAULT_LON="-46.6333"
+DEFAULT_ISO="2025-09-21T13:00:00Z"
+```
+
+## Scripts
+
+```bash
+pnpm dev          # desenvolvimento http
+pnpm dev:https    # desenvolvimento https experimental
+pnpm build        # build de produção
+pnpm start        # serve build de produção
+```
+
+## Rotas importantes
+
+- `/origination/tiles`: viewer Three.js + 3D Tiles com painel de posição solar.
+- `/origination/3d-tiles-proposal`: resumo da proposta de implantação.
+- `/api/tiles/[...path]`: proxy para tiles (resolve CORS/assinaturas).
+- `/api/solpos`: ponte para o serviço FastAPI `geo_solar`.
+
+## Desenvolvimento do backend solar
+
+O serviço FastAPI correspondente está em `ysh/domains/geo_solar/app.py`. Utilize `uvicorn` para executá-lo localmente.
+
+## Conversão de dados em 3D Tiles
+
+Use [`py3dtiles`](https://github.com/Oslandia/py3dtiles) para converter nuvens de pontos LAS/LAZ em tiles OGC 3D Tiles.
+
+```bash
+pip install py3dtiles
+py3dtiles convert path/to/input.las ./tiles/out_city
+```
+
+Publique o diretório resultante (contendo `tileset.json`) em um CDN ou sirva via proxy `/api/tiles/...`.

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/app/api/solpos/route.ts
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/app/api/solpos/route.ts
@@ -1,0 +1,38 @@
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const lat = searchParams.get("lat");
+    const lon = searchParams.get("lon");
+    const iso = searchParams.get("iso");
+
+    const base = process.env.SOLAR_API_BASE ?? "http://localhost:8000";
+    const upstream = `${base.replace(/\/$/, "")}/solpos?lat=${lat ?? ""}&lon=${lon ?? ""}&iso=${encodeURIComponent(iso ?? "")}`;
+
+    const response = await fetch(upstream, {
+      method: "GET",
+      redirect: "manual",
+      headers: { accept: "application/json" }
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      return new Response(
+        JSON.stringify({ error: "Backend returned redirect. Serve FastAPI over HTTPS or disable redirects." }),
+        {
+          status: 502,
+          headers: { "content-type": "application/json" }
+        }
+      );
+    }
+
+    const payload = await response.text();
+    return new Response(payload, {
+      status: response.status,
+      headers: { "content-type": "application/json" }
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: String(error) }), {
+      status: 500,
+      headers: { "content-type": "application/json" }
+    });
+  }
+}

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/app/api/tiles/[...path]/route.ts
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/app/api/tiles/[...path]/route.ts
@@ -1,0 +1,30 @@
+export const runtime = "edge";
+
+export async function GET(_req: Request, ctx: { params: { path: string[] } }) {
+  const path = ctx.params.path.join("/");
+  const host = process.env.TILES_HOST;
+
+  if (!host) {
+    return new Response(JSON.stringify({ error: "Missing TILES_HOST environment variable" }), {
+      status: 500,
+      headers: { "content-type": "application/json" }
+    });
+  }
+
+  const upstream = `https://${host}/${path}`;
+
+  const response = await fetch(upstream, {
+    headers: {
+      "User-Agent": "YSH-TilesProxy"
+    }
+  });
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: {
+      "content-type": response.headers.get("content-type") ?? "application/octet-stream",
+      "cache-control": response.headers.get("cache-control") ?? "public, max-age=3600",
+      "access-control-allow-origin": "*"
+    }
+  });
+}

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/app/globals.css
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/app/globals.css
@@ -1,0 +1,85 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.4;
+}
+
+body {
+  margin: 0;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+main.page {
+  padding: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+a.link {
+  color: #1d4ed8;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+a.link:hover {
+  text-decoration: underline;
+}
+
+.ysh-gradient-border {
+  border: 1px solid transparent;
+  background: linear-gradient(#ffffff, #ffffff) padding-box,
+    linear-gradient(135deg, #4f46e5, #06b6d4) border-box;
+}
+
+input {
+  font: inherit;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+section.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.viewer {
+  height: 75vh;
+  border-radius: 12px;
+  position: relative;
+}
+
+.viewer.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1.5rem;
+  color: #475569;
+  background: rgba(15, 23, 42, 0.03);
+}
+
+article.proposal {
+  padding: 2rem;
+  border-radius: 16px;
+  background: white;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(79, 70, 229, 0.25);
+}
+
+article.proposal ul {
+  margin: 1rem 0 0;
+  padding-left: 1.25rem;
+}
+
+article.proposal li {
+  margin-bottom: 0.5rem;
+}

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/app/layout.tsx
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Origination Geo Frontend",
+  description: "3D Tiles viewer with solar controls"
+};
+
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/app/origination/3d-tiles-proposal/page.tsx
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/app/origination/3d-tiles-proposal/page.tsx
@@ -1,0 +1,23 @@
+export default function ProposalPage() {
+  return (
+    <main className="page">
+      <article className="proposal">
+        <header>
+          <h1>Incorporação 3D Tiles (OGC) · YSH</h1>
+          <p>Next 15 + Three.js + 3D Tiles + solposx + FastAPI</p>
+        </header>
+        <section>
+          <p>
+            Streaming 3D geoespacial com TilesRenderer (Three.js), tiles via CDN/Proxy e iluminação solar (solposx).
+          </p>
+          <ul>
+            <li>Viewer: <code>components/geo/ThreeTilesViewer.tsx</code></li>
+            <li>Página: <code>/origination/tiles</code></li>
+            <li>Proxy: <code>/api/tiles/[...path]</code></li>
+            <li>Solar API: <code>domains/geo_solar/app.py</code></li>
+          </ul>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/app/origination/tiles/page.tsx
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/app/origination/tiles/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import ThreeTilesViewer from "../../../components/geo/ThreeTilesViewer";
+
+type EnvDefaults = {
+  lat: number;
+  lon: number;
+  iso: string;
+};
+
+function resolveEnvDefaults(): EnvDefaults {
+  const fallbackLat = process.env.NEXT_PUBLIC_DEFAULT_LAT ?? process.env.DEFAULT_LAT ?? "-23.5505";
+  const fallbackLon = process.env.NEXT_PUBLIC_DEFAULT_LON ?? process.env.DEFAULT_LON ?? "-46.6333";
+  const fallbackIso = process.env.DEFAULT_ISO ?? new Date().toISOString();
+
+  return {
+    lat: Number(fallbackLat),
+    lon: Number(fallbackLon),
+    iso: fallbackIso
+  };
+}
+
+export default function TilesPage() {
+  const defaults = useMemo(resolveEnvDefaults, []);
+  const [lat, setLat] = useState<number>(defaults.lat);
+  const [lon, setLon] = useState<number>(defaults.lon);
+  const [iso, setIso] = useState<string>(defaults.iso);
+
+  useEffect(() => {
+    if (Number.isNaN(lat)) {
+      setLat(defaults.lat);
+    }
+    if (Number.isNaN(lon)) {
+      setLon(defaults.lon);
+    }
+  }, [defaults.lat, defaults.lon, lat, lon]);
+
+  const tilesetUrl = process.env.NEXT_PUBLIC_TILESET_URL;
+
+  return (
+    <main className="page">
+      <section className="grid">
+        <label>
+          <span>Latitude</span>
+          <input value={lat} onChange={(event) => setLat(Number(event.target.value))} />
+        </label>
+        <label>
+          <span>Longitude</span>
+          <input value={lon} onChange={(event) => setLon(Number(event.target.value))} />
+        </label>
+        <label>
+          <span>ISO Datetime</span>
+          <input value={iso} onChange={(event) => setIso(event.target.value)} />
+        </label>
+      </section>
+
+      {tilesetUrl ? (
+        <ThreeTilesViewer tilesetUrl={tilesetUrl} lat={lat} lon={lon} iso={iso} solarApiBase="/api/solpos" />
+      ) : (
+        <div className="viewer placeholder ysh-gradient-border">
+          <p>Configure NEXT_PUBLIC_TILESET_URL no arquivo .env.local para carregar o tileset.</p>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/app/page.tsx
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/app/page.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <main className="page">
+      <section>
+        <h1>Origination Geo Frontend</h1>
+        <p>
+          Explore photovoltaic origination sites with an interactive 3D Tiles viewer and solar illumination controls.
+        </p>
+      </section>
+      <section>
+        <Link className="link" href="/origination/tiles">
+          Abrir visualizador 3D Tiles
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/components/geo/ThreeTilesViewer.tsx
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/components/geo/ThreeTilesViewer.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { TilesRenderer } from "3d-tiles-renderer";
+
+type ThreeTilesViewerProps = {
+  tilesetUrl: string;
+  lat?: number;
+  lon?: number;
+  iso?: string;
+  solarApiBase?: string;
+};
+
+export default function ThreeTilesViewer({
+  tilesetUrl,
+  lat,
+  lon,
+  iso,
+  solarApiBase = "/api/solpos"
+}: ThreeTilesViewerProps) {
+  const container = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = container.current;
+    if (!el) {
+      return;
+    }
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(el.clientWidth, el.clientHeight);
+    el.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0xfafafa);
+
+    const camera = new THREE.PerspectiveCamera(60, el.clientWidth / el.clientHeight, 0.1, 1_000_000_000);
+    camera.position.set(1500, 1500, 1500);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.2);
+    const sun = new THREE.DirectionalLight(0xffffff, 1.0);
+    sun.position.set(1000, 2000, 1000);
+    scene.add(ambient, sun);
+
+    const tiles = new TilesRenderer(tilesetUrl);
+    tiles.setCamera(camera);
+    tiles.setResolutionFromRenderer(camera, renderer);
+    scene.add(tiles.group);
+
+    let isDragging = false;
+    let prev = { x: 0, y: 0 };
+
+    const handleMouseDown = (event: MouseEvent) => {
+      isDragging = true;
+      prev = { x: event.clientX, y: event.clientY };
+    };
+
+    const handleMouseUp = () => {
+      isDragging = false;
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+      if (!isDragging) {
+        return;
+      }
+      const dx = (event.clientX - prev.x) * 0.005;
+      const dy = (event.clientY - prev.y) * 0.005;
+      prev = { x: event.clientX, y: event.clientY };
+      camera.position.applyAxisAngle(new THREE.Vector3(0, 1, 0), -dx);
+      camera.position.y = Math.max(10, camera.position.y + dy * 200);
+      camera.lookAt(0, 0, 0);
+    };
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const scale = Math.exp(-event.deltaY * 0.001);
+      camera.position.multiplyScalar(scale);
+    };
+
+    el.addEventListener("mousedown", handleMouseDown);
+    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("mousemove", handleMouseMove);
+    el.addEventListener("wheel", handleWheel, { passive: false });
+
+    const handleResize = () => {
+      const width = el.clientWidth;
+      const height = el.clientHeight;
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      renderer.setSize(width, height);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    async function updateSunDirection() {
+      if (lat == null || lon == null || !iso) {
+        return;
+      }
+
+      try {
+        const params = new URLSearchParams({ lat: String(lat), lon: String(lon), iso });
+        const response = await fetch(`${solarApiBase}?${params.toString()}`);
+        const { azimuth_deg: azimuthDeg, elevation_deg: elevationDeg } = await response.json();
+
+        if (typeof azimuthDeg === "number" && typeof elevationDeg === "number") {
+          const azimuth = (azimuthDeg * Math.PI) / 180;
+          const elevation = (elevationDeg * Math.PI) / 180;
+          const radius = 5000;
+          const x = radius * Math.cos(elevation) * Math.sin(azimuth);
+          const y = radius * Math.sin(elevation);
+          const z = radius * Math.cos(elevation) * Math.cos(azimuth);
+          sun.position.set(x, y, z);
+        }
+      } catch (error) {
+        console.error("solpos error", error);
+      }
+    }
+
+    updateSunDirection();
+
+    let animationId = 0;
+    const loop = () => {
+      animationId = requestAnimationFrame(loop);
+      tiles.update();
+      renderer.render(scene, camera);
+    };
+    loop();
+
+    return () => {
+      cancelAnimationFrame(animationId);
+      window.removeEventListener("resize", handleResize);
+      window.removeEventListener("mouseup", handleMouseUp);
+      window.removeEventListener("mousemove", handleMouseMove);
+      el.removeEventListener("mousedown", handleMouseDown);
+      el.removeEventListener("wheel", handleWheel);
+      el.replaceChildren();
+      tiles.dispose();
+      renderer.dispose();
+    };
+  }, [iso, lat, lon, solarApiBase, tilesetUrl]);
+
+  return <div ref={container} className="viewer ysh-gradient-border" />;
+}

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/next-env.d.ts
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/next.config.mjs
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/package.json
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "geo-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "dev:https": "next dev --experimental-https",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "3d-tiles-renderer": "^0.4.7",
+    "next": "^15.0.0-canary.118",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.168.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^15.0.0-canary.118",
+    "typescript": "^5.5.4"
+  },
+  "packageManager": "pnpm@9.7.1"
+}

--- a/ysh/domains/origination-viabilidade/apps/geo_frontend/tsconfig.json
+++ b/ysh/domains/origination-viabilidade/apps/geo_frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Next.js 15 geo_frontend app with a Three.js 3D Tiles viewer, proxy routes, and solar controls
- document environment variables, data conversion workflow, and ship default styling plus proposal page
- introduce the geo_solar FastAPI service that returns solar azimuth/elevation and list its Python dependencies

## Testing
- python -m compileall ysh/domains/geo_solar/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d18d383b508332966aed3ccbf86f04