### PR TITLE
feat(origination-viabilidade): add geo KPI enrichment pipeline

### DIFF
--- a/ysh/domains/origination-viabilidade/apps/origination_api/app/routers/leads.py
+++ b/ysh/domains/origination-viabilidade/apps/origination_api/app/routers/leads.py
@@ -6,9 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import SessionLocal
 from app.events.nats_bus import SUBJECTS, publish
-from app.models.leads import Lead, LeadFeatures, Recommendation
+from app.models.leads import Lead, LeadFeatures, LeadGeoKPIs, Recommendation
 from app.schemas.leads import (
     ClassifyIn,
+    GeoKPIIn,
+    GeoKPIOut,
     LeadCreate,
     LeadOut,
     ModalityIn,
@@ -16,6 +18,7 @@ from app.schemas.leads import (
     SizingIn,
     SizingOut,
 )
+from app.services.geo_enrichment import build_geo_key, build_geojson_feature
 from app.services.recommendations import PROJECT_BANDS, TIERS, build_bundle
 from app.services.sizing import choose_band, sizing_summary
 
@@ -91,6 +94,70 @@ async def classify_lead(
         },
     )
     return {"ok": True}
+
+
+@router.post(
+    "/leads/{lead_id}/geo-kpis",
+    response_model=GeoKPIOut,
+    summary="Registrar dados GeoJSON enriquecidos com KPIs regulatórios",
+)
+async def upsert_geo_kpis(
+    lead_id: str,
+    body: GeoKPIIn,
+    db: AsyncSession = Depends(get_db),
+):
+    lead = await db.get(Lead, lead_id)
+    if not lead:
+        raise HTTPException(404, "lead not found")
+
+    composite_key = build_geo_key(body.cpf, body.cep, body.latitude, body.longitude)
+    feature = build_geojson_feature(
+        cpf=body.cpf,
+        cep=body.cep,
+        latitude=body.latitude,
+        longitude=body.longitude,
+        kpis=body.kpis.model_dump(),
+        properties=body.properties,
+    )
+
+    existing = await db.get(LeadGeoKPIs, composite_key)
+    if existing and existing.lead_id != lead_id:
+        raise HTTPException(409, "geo KPIs belong to another lead")
+    if existing:
+        target = existing
+    else:
+        target = LeadGeoKPIs(composite_key=composite_key, lead_id=lead_id)
+        db.add(target)
+
+    props = feature["properties"]
+    target.lead_id = lead_id
+    target.cpf = props.get("cpf", "")
+    target.cep = props.get("cep", "")
+    target.latitude = feature["geometry"]["coordinates"][1]
+    target.longitude = feature["geometry"]["coordinates"][0]
+    target.properties = props
+    target.kpis = props.get("kpis", {})
+    target.geojson = feature
+
+    await db.commit()
+    await db.refresh(target)
+    return GeoKPIOut.model_validate(target)
+
+
+@router.get(
+    "/leads/{lead_id}/geo-kpis",
+    response_model=GeoKPIOut,
+    summary="Consultar KPIs geoespaciais do lead",
+)
+async def get_geo_kpis(lead_id: str, db: AsyncSession = Depends(get_db)):
+    record = (
+        await db.execute(
+            select(LeadGeoKPIs).where(LeadGeoKPIs.lead_id == lead_id)
+        )
+    ).scalar_one_or_none()
+    if not record:
+        raise HTTPException(404, "geo KPIs not found")
+    return GeoKPIOut.model_validate(record)
 
 
 @router.post(

--- a/ysh/domains/origination-viabilidade/apps/origination_api/app/services/geo_enrichment.py
+++ b/ysh/domains/origination-viabilidade/apps/origination_api/app/services/geo_enrichment.py
@@ -1,0 +1,117 @@
+"""Utilities for composing GeoJSON features enriched with regulatory KPIs.
+
+The enrichment process consolidates KPIs from public data sources (BACEN, EPE,
+ANEEL, IBGE and QUOD) into a single GeoJSON feature keyed by the tuple
+``CPF + CEP + LAT + LNG``.  Keeping this logic in a dedicated module allows the
+REST layer to remain thin while enabling unit tests to cover the geospatial
+normalisation behaviour without the need for a database.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import re
+
+# The KPI providers we expect to receive for each enriched lead.  Keeping the
+# list centralised makes it easy to extend in the future and avoids scattering
+# literal strings across the codebase.
+EXPECTED_KPI_KEYS = ("bacen", "epe", "aneel", "ibge", "quod")
+
+_NUMERIC_PATTERN = re.compile(r"\D+")
+
+
+def _sanitize_numeric(value: str | None) -> str:
+    """Return only the numeric characters contained in ``value``."""
+
+    if not value:
+        return ""
+    return _NUMERIC_PATTERN.sub("", value)
+
+
+def _normalise_coordinate(value: float) -> float:
+    """Round coordinates to six decimal places to stabilise the compound key."""
+
+    return round(float(value), 6)
+
+
+def build_geo_key(cpf: str, cep: str, latitude: float, longitude: float) -> str:
+    """Compose a stable key using the CPF, CEP and geographic coordinates.
+
+    The CPF and CEP are stripped from any punctuation so that ``123.456.789-00``
+    and ``12345678900`` map to the same key.  Coordinates are rounded to reduce
+    floating point noise and ensure that serialisations coming from different
+    providers still collapse into the same identity.
+    """
+
+    cpf_clean = _sanitize_numeric(cpf)
+    cep_clean = _sanitize_numeric(cep)
+    lat = _normalise_coordinate(latitude)
+    lon = _normalise_coordinate(longitude)
+    return f"{cpf_clean}:{cep_clean}:{lat:.6f}:{lon:.6f}"
+
+
+def ensure_kpi_payload(kpis: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Guarantee the presence of the expected KPI namespaces.
+
+    Any missing namespace defaults to an empty mapping which simplifies the
+    serialisation logic downstream and yields predictable schemas for the API
+    consumer.
+    """
+
+    payload: dict[str, Any] = {name: {} for name in EXPECTED_KPI_KEYS}
+    if not kpis:
+        return payload
+    for key, value in kpis.items():
+        if key in payload and value is not None:
+            payload[key] = value
+    return payload
+
+
+def build_geojson_feature(
+    *,
+    cpf: str,
+    cep: str,
+    latitude: float,
+    longitude: float,
+    kpis: Mapping[str, Any] | None = None,
+    properties: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a GeoJSON feature embedding the KPI payload.
+
+    Additional properties supplied by callers are merged with the core
+    attributes (CPF, CEP and the KPI namespaces).  The feature ``id`` mirrors
+    the compound key used in the database which helps clients correlate stored
+    records with API responses.
+    """
+
+    kpi_payload = ensure_kpi_payload(kpis)
+    cpf_clean = _sanitize_numeric(cpf)
+    cep_clean = _sanitize_numeric(cep)
+    base_properties: dict[str, Any] = {
+        "cpf": cpf_clean,
+        "cep": cep_clean,
+        "kpis": kpi_payload,
+    }
+    if properties:
+        base_properties.update(properties)
+    return {
+        "type": "Feature",
+        "id": build_geo_key(cpf_clean, cep_clean, latitude, longitude),
+        "geometry": {
+            "type": "Point",
+            "coordinates": [
+                _normalise_coordinate(longitude),
+                _normalise_coordinate(latitude),
+            ],
+        },
+        "properties": base_properties,
+    }
+
+
+__all__ = [
+    "EXPECTED_KPI_KEYS",
+    "build_geo_key",
+    "build_geojson_feature",
+    "ensure_kpi_payload",
+]

--- a/ysh/domains/origination-viabilidade/apps/origination_api/tests/test_geo_enrichment.py
+++ b/ysh/domains/origination-viabilidade/apps/origination_api/tests/test_geo_enrichment.py
@@ -1,0 +1,39 @@
+from app.services.geo_enrichment import (
+    build_geo_key,
+    build_geojson_feature,
+    ensure_kpi_payload,
+)
+
+
+def test_build_geo_key_normalises_inputs() -> None:
+    key = build_geo_key("123.456.789-00", "01310-000", -23.56123, -46.6551)
+    assert key == "12345678900:01310000:-23.561230:-46.655100"
+
+
+def test_ensure_kpi_payload_fills_missing_namespaces() -> None:
+    payload = ensure_kpi_payload({"bacen": {"selic": 0.1}, "ibge": None})
+    assert set(payload.keys()) == {"bacen", "epe", "aneel", "ibge", "quod"}
+    assert payload["bacen"] == {"selic": 0.1}
+    assert payload["epe"] == {}
+    assert payload["ibge"] == {}
+
+
+def test_build_geojson_feature_embeds_kpis_and_properties() -> None:
+    feature = build_geojson_feature(
+        cpf="987.654.321-00",
+        cep="22071-060",
+        latitude=-22.971177,
+        longitude=-43.182543,
+        kpis={"aneel": {"distributor": "LIGHT"}},
+        properties={"segment": "residential"},
+    )
+
+    assert feature["type"] == "Feature"
+    assert feature["geometry"] == {
+        "type": "Point",
+        "coordinates": [-43.182543, -22.971177],
+    }
+    assert feature["properties"]["cpf"] == "98765432100"
+    assert feature["properties"]["cep"] == "22071060"
+    assert feature["properties"]["segment"] == "residential"
+    assert feature["properties"]["kpis"]["aneel"] == {"distributor": "LIGHT"}

--- a/ysh/domains/origination-viabilidade/data/schemas/postgres_ysh_leads.sql
+++ b/ysh/domains/origination-viabilidade/data/schemas/postgres_ysh_leads.sql
@@ -22,3 +22,20 @@ CREATE TABLE IF NOT EXISTS ysh.leads (
   region TEXT,
   status TEXT
 );
+
+CREATE TABLE IF NOT EXISTS ysh.lead_geo_kpis (
+  composite_key TEXT PRIMARY KEY,
+  lead_id UUID UNIQUE REFERENCES ysh.leads(lead_id),
+  cpf TEXT NOT NULL,
+  cep TEXT NOT NULL,
+  latitude DOUBLE PRECISION NOT NULL,
+  longitude DOUBLE PRECISION NOT NULL,
+  properties JSONB DEFAULT '{}'::jsonb,
+  kpis JSONB DEFAULT '{}'::jsonb,
+  geojson JSONB NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS lead_geo_kpis_identity_idx
+  ON ysh.lead_geo_kpis (cpf, cep, latitude, longitude);


### PR DESCRIPTION
## Summary
- add geo enrichment utilities that produce GeoJSON features keyed by CPF+CEP+lat/lng
- persist the KPI payload alongside leads and expose endpoints to upsert and fetch geo KPIs
- extend the SQL schema and unit tests covering KPI namespace normalisation

## Testing
- pytest ysh/domains/origination-viabilidade/apps/origination_api/tests/test_geo_enrichment.py

------
https://chatgpt.com/codex/tasks/task_e_68d18cd5a564833294d1db6594cc7416