### PR TITLE
Fix viability service helpers and add tests

### DIFF
--- a/ysh/domains/origination-viabilidade/apps/viability_service/app/__init__.py
+++ b/ysh/domains/origination-viabilidade/apps/viability_service/app/__init__.py
@@ -1,0 +1,8 @@
+"""YSH Viability service application package."""
+
+# The subpackages (events, services, meteo) expose the public API expected by
+# the FastAPI application and by the tests.  Keeping this file intentionally
+# minimal avoids introducing heavy imports at package initialisation time while
+# still enabling ``app.services`` style imports.
+
+__all__ = ["events", "services", "meteo"]

--- a/ysh/domains/origination-viabilidade/apps/viability_service/app/events/nats_bus.py
+++ b/ysh/domains/origination-viabilidade/apps/viability_service/app/events/nats_bus.py
@@ -35,16 +35,17 @@ async def nats_lifespan(app) -> AsyncIterator[None]:
             await nc.drain()
 
 
-async def publish_completed(payload: dict):
+async def publish_completed(payload: dict) -> bool:
     """Publica um evento de viabilidade concluída."""
-    if nc:
-        try:
-            await nc.publish(SUBJECT_COMPLETED, json.dumps(payload).encode())
-            print(f"Publicado evento {SUBJECT_COMPLETED}: {payload}")
-            return True
-        except Exception as e:
-            print(f"Erro ao publicar evento {SUBJECT_COMPLETED}: {e}")
-            return False
-    return False            print(f"Erro ao publicar evento {SUBJECT_COMPLETED}: {e}")
-            return False
-    return False
+
+    if not nc:
+        return False
+
+    try:
+        await nc.publish(SUBJECT_COMPLETED, json.dumps(payload).encode())
+    except Exception as exc:  # pragma: no cover - defensive logging
+        print(f"Erro ao publicar evento {SUBJECT_COMPLETED}: {exc}")
+        return False
+
+    print(f"Publicado evento {SUBJECT_COMPLETED}: {payload}")
+    return True

--- a/ysh/domains/origination-viabilidade/apps/viability_service/app/meteo/nasa_power.py
+++ b/ysh/domains/origination-viabilidade/apps/viability_service/app/meteo/nasa_power.py
@@ -215,7 +215,7 @@ def get_annual_insolation(latitude: float, longitude: float) -> Dict[str, float]
         return {
             'ghi_annual': round(ghi_annual, 1),
             'dni_annual': round(dni_annual, 1),
-            'is_estimated': False
+            'is_estimated': False,
         }
     except Exception as e:
         print(f"Erro ao calcular insolação anual: {str(e)}")
@@ -223,6 +223,5 @@ def get_annual_insolation(latitude: float, longitude: float) -> Dict[str, float]
         return {
             'ghi_annual': 1825.0,  # 5 kWh/m²/dia * 365 dias
             'dni_annual': 2007.5,  # 5.5 kWh/m²/dia * 365 dias
-            'is_estimated': True
-        }            'is_estimated': True
+            'is_estimated': True,
         }

--- a/ysh/domains/origination-viabilidade/apps/viability_service/app/meteo/pv_system.py
+++ b/ysh/domains/origination-viabilidade/apps/viability_service/app/meteo/pv_system.py
@@ -264,8 +264,6 @@ def simplified_estimate(
             'data_source': "Simplified Estimate" if insolation['is_estimated'] else "NASA POWER Annual",
             'mount_type': "fixed",
             'tilt': "optimal",
-            'azimuth': "optimal"
-        }
-    }            'azimuth': "optimal"
-        }
+            'azimuth': "optimal",
+        },
     }

--- a/ysh/domains/origination-viabilidade/apps/viability_service/app/services/__init__.py
+++ b/ysh/domains/origination-viabilidade/apps/viability_service/app/services/__init__.py
@@ -1,0 +1,13 @@
+"""Service layer helpers for the viability microservice."""
+
+from .economics import EconomicsIn, EconomicsOut, evaluate  # noqa: F401
+from .viability import ViabilityIn, ViabilityOut, compute_viability  # noqa: F401
+
+__all__ = [
+    "EconomicsIn",
+    "EconomicsOut",
+    "ViabilityIn",
+    "ViabilityOut",
+    "compute_viability",
+    "evaluate",
+]

--- a/ysh/domains/origination-viabilidade/apps/viability_service/app/services/economics.py
+++ b/ysh/domains/origination-viabilidade/apps/viability_service/app/services/economics.py
@@ -94,5 +94,5 @@ def evaluate(in_: EconomicsIn) -> EconomicsOut:
         roi_pct=round(roi, 1),
         payback_years=float(payback),
         tir_pct=round(tir, 1),
-        cashflow=[round(x, 2) for x in cash]
-    )    )
+        cashflow=[round(x, 2) for x in cash],
+    )

--- a/ysh/domains/origination-viabilidade/apps/viability_service/tests/conftest.py
+++ b/ysh/domains/origination-viabilidade/apps/viability_service/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Pytest configuration for the viability service tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def _ensure_app_on_path() -> None:
+    root = Path(__file__).resolve().parents[1]
+    app_dir = root / "app"
+    if str(app_dir) not in sys.path:
+        sys.path.insert(0, str(root))
+
+
+_ensure_app_on_path()
+
+__all__ = []

--- a/ysh/domains/origination-viabilidade/apps/viability_service/tests/test_economics.py
+++ b/ysh/domains/origination-viabilidade/apps/viability_service/tests/test_economics.py
@@ -1,0 +1,29 @@
+"""Tests for the economic viability helpers."""
+
+from app.services.economics import EconomicsIn, evaluate
+
+
+def test_evaluate_returns_rounded_metrics() -> None:
+    """The economics evaluation should round its numeric outputs."""
+
+    result = evaluate(
+        EconomicsIn(
+            kwh_year=15_000,
+            tariff_profile={"cents_per_kwh": 80},
+            capex=10_000,
+            opex=500,
+            lifetime_years=5,
+            degradation_pct_year=0.5,
+        )
+    )
+
+    assert result.payback_years == 1.0
+    assert result.roi_pct == 469.0
+    assert result.tir_pct == 1.0
+    assert result.cashflow == [
+        1500.0,
+        11440.0,
+        11380.3,
+        11320.9,
+        11261.79,
+    ]

--- a/ysh/domains/origination-viabilidade/apps/viability_service/tests/test_nats_bus.py
+++ b/ysh/domains/origination-viabilidade/apps/viability_service/tests/test_nats_bus.py
@@ -1,0 +1,34 @@
+"""Tests for the NATS helper utilities."""
+
+import json
+
+import pytest
+
+from app.events import nats_bus
+
+
+class _DummyNC:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes]] = []
+
+    async def publish(self, subject: str, data: bytes) -> None:
+        self.published.append((subject, data))
+
+
+@pytest.mark.asyncio
+async def test_publish_completed_returns_true_when_connected(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy = _DummyNC()
+    monkeypatch.setattr(nats_bus, "nc", dummy, raising=False)
+
+    payload = {"lead_id": "123", "result": "ok"}
+    assert await nats_bus.publish_completed(payload) is True
+    assert dummy.published == [
+        (nats_bus.SUBJECT_COMPLETED, json.dumps(payload).encode()),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_publish_completed_returns_false_without_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(nats_bus, "nc", None, raising=False)
+
+    assert await nats_bus.publish_completed({"lead_id": "missing"}) is False


### PR DESCRIPTION
## Summary
- fix the viability service NATS publisher to handle missing connections and exceptions cleanly
- clean up the economics and meteo helpers so their return payloads are valid and well formatted
- add package initialisers and pytest coverage for economics calculations and NATS publishing

## Testing
- `uv run --with-requirements ysh/domains/origination-viabilidade/requirements-dev.txt --project ysh/domains/origination-viabilidade/apps/viability_service pytest ysh/domains/origination-viabilidade/apps/viability_service/tests`


------
https://chatgpt.com/codex/tasks/task_e_68d1c0f9e1988332a6e8554a36fa0d3d