### PR TITLE
Integrate solar domain breakdown across viability stack

### DIFF
--- a/samples/python/src/roles/solar_viability_agent/agent.py
+++ b/samples/python/src/roles/solar_viability_agent/agent.py
@@ -23,20 +23,32 @@ root_agent = RetryingLlmAgent(
     model="gemini-1.5-flash",
     name="solar_viability_agent",
     instruction="""
-          You are a solar viability agent. Your role is to analyze the solar
-          viability of a given location based on latitude, longitude, and other
-          parameters.
+          You are a solar viability agent embedded in the AP2 stack. Every
+          response must map to the four technical domains of the solar
+          performance workflow used by our FastAPI services and MCP agent:
 
-          Follow these instructions:
-          1. When the user asks for solar viability, use the available tools
-             to calculate solar position, irradiance, and PV system performance.
-          2. Present the results to the user in a clear and understandable way.
+          1. Solar Geometry — establish the spatio-temporal frame (latitude,
+             longitude, altitude, solar zenith/azimuth from the Solar Position
+             Algorithm or equivalent).
+          2. Radiometric & Climatological Modelling — characterise the resource
+             using irradiance components (GHI, DNI, DHI), atmospheric inputs and
+             transposition to the plane-of-array (POA).
+          3. PV Conversion Chain — simulate module + inverter behaviour using
+             pvlib ModelChain (thermal, optical, electrical effects) and note
+             any system-loss assumptions.
+          4. Performance & Viability Indicators — quantify energy yield,
+             Performance Ratio, capacity factor and any losses/KPIs needed by
+             downstream Origination/MCP flows.
+
+          When the user asks for solar viability, call the tools to cover these
+          domains in order. Report back using Markdown with four sections (one
+          per domain), highlighting the indicators supplied by each tool. If a
+          tool call fails or data are missing, explain the fallback that was
+          applied so the MCP orchestrator can trace the gap.
           """,
     tools=[
         tools.calculate_solar_position,
         tools.get_irradiance,
         tools.get_pvsystem_performance,
-    ],
-)
     ],
 )

--- a/ysh/domains/geo_solar/app.py
+++ b/ysh/domains/geo_solar/app.py
@@ -35,4 +35,10 @@ def solpos(lat: float, lon: float, iso: str) -> dict[str, float | str]:
         dt = dt.astimezone(timezone.utc)
 
     solar = solar_position(latitude=lat, longitude=lon, timestamp=dt)
-    return {"azimuth_deg": solar.azimuth, "elevation_deg": solar.elevation}
+    return {
+        "domain": "solar_geometry",
+        "summary": "Efeméride instantânea calculada via solposx (SPA).",
+        "timestamp_utc": dt.isoformat(),
+        "azimuth_deg": solar.azimuth,
+        "elevation_deg": solar.elevation,
+    }

--- a/ysh/domains/origination-viabilidade/mcp/manifests/pre_orchestrator_agent.json
+++ b/ysh/domains/origination-viabilidade/mcp/manifests/pre_orchestrator_agent.json
@@ -183,7 +183,7 @@
             {
                   "id": "calculate_viability",
                   "name": "Calcular Viabilidade",
-                  "description": "Calcula a viabilidade técnica do sistema solar baseado na localização e outros parâmetros.",
+                  "description": "Calcula a viabilidade técnica do sistema solar e retorna o breakdown 4-domínios (geometria solar, clima radiométrico, cadeia FV e KPIs de performance).",
                   "parameters": {
                         "type": "object",
                         "properties": {


### PR DESCRIPTION
## Summary
- align the solar viability LLM agent prompts and tool outputs with the four-domain solar analysis workflow so responses are structured for MCP/AP2 consumption
- extend the viability service pipeline (NASA, clearsky and fallback paths) to emit a domain breakdown alongside kWh/year and PR metrics, surfacing indicators for geometry, climate, conversion and performance
- tag the geo_solar solpos API and MCP manifest with the new domain metadata to expose the context to FastAPI clients

## Testing
- python -m compileall samples/python/src/roles/solar_viability_agent ysh/domains/origination-viabilidade/apps/viability_service ysh/domains/geo_solar
- pytest ysh/domains/origination-viabilidade/apps/viability_service/tests -q *(fails: missing optional deps pydantic/nats)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c655e5588332986a455d3d8f5469